### PR TITLE
Bump confluentVersion from 7.6.0 to 7.6.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ repositories {
 }
 
 val caffeineVersion = "3.1.8"
-val confluentVersion = "7.6.0"
+val confluentVersion = "7.6.1"
 val mockitoKotlinVersion = "2.2.0"
 val ojdbc8Version = "19.3.0.0"
 val avroVersion = "1.11.3"
@@ -69,6 +69,7 @@ dependencies {
     testImplementation("no.nav.security:token-validation-spring-test:$tokenSupportVersion")
     testImplementation("com.networknt:json-schema-validator:$jsonSchemaValidatorVersion")
     testImplementation("org.amshove.kluent:kluent:$kluentVersion")
+    testImplementation("commons-codec:commons-codec")
 }
 
 kotlin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,8 +28,6 @@ repositories {
 
 val caffeineVersion = "3.1.8"
 val confluentVersion = "7.6.0"
-val syfoKafkaVersion = "2021.07.20-09.39-6be2c52c"
-val sykepengesoknadKafkaVersion = "2023.08.21-12.33-c161cca9"
 val mockitoKotlinVersion = "2.2.0"
 val ojdbc8Version = "19.3.0.0"
 val avroVersion = "1.11.3"

--- a/src/test/kotlin/FellesTestOppsett.kt
+++ b/src/test/kotlin/FellesTestOppsett.kt
@@ -32,7 +32,7 @@ abstract class FellesTestOppsett {
             val threads = mutableListOf<Thread>()
 
             thread {
-                KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.3")).apply {
+                KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.1")).apply {
                     start()
                     System.setProperty("KAFKA_BROKERS", bootstrapServers)
                     System.setProperty("AIVEN_DOKUMENT_TOPIC", "test-topic")


### PR DESCRIPTION
Oppgraderer Kafka Testcontainers og angir dependency til commonds-codec på grunn av optional transitiv avhengighet.